### PR TITLE
Parancsgenerálás

### DIFF
--- a/packages/device-comm/src/command_gen.ts
+++ b/packages/device-comm/src/command_gen.ts
@@ -97,6 +97,17 @@ export class RequestSelftestCommandBody implements ICommandBody {
   }
 }
 
+export class EmptyCommandBody implements ICommandBody {
+  constructor() {}
+
+  generateBody(): Buffer {
+    const body = Buffer.alloc(5);
+    body.writeUint32LE(0, 0);
+    body.writeUint8(0, 4);
+    return body;
+  }
+}
+
 /// COMMAND GENERATION
 
 export interface IRawCommand {
@@ -145,6 +156,22 @@ const commandRegistry: Record<string, CommandRegistryItem> = {
     typeCode: 0x06,
     bodyGenerator: (data: any) =>
       new RequestSelftestCommandBody(data.timestamp),
+  },
+  RESET: {
+    typeCode: 0x0f,
+    bodyGenerator: (data: any) => new EmptyCommandBody(),
+  },
+  RESTART: {
+    typeCode: 0x0e,
+    bodyGenerator: (data: any) => new EmptyCommandBody(),
+  },
+  SAVE: {
+    typeCode: 0xaa,
+    bodyGenerator: (data: any) => new EmptyCommandBody(),
+  },
+  STOP: {
+    typeCode: 0xbb,
+    bodyGenerator: (data: any) => new EmptyCommandBody(),
   },
 };
 

--- a/packages/device-comm/test/command_gen.test.ts
+++ b/packages/device-comm/test/command_gen.test.ts
@@ -69,3 +69,55 @@ test("Request Selftest generation", function request_selftest() {
 
   expect(actual).toEqual(expected);
 });
+
+test("Reset generation", function reset() {
+  const command: IRawCommand = {
+    id: 1,
+    type: "RESET",
+    params: {},
+  };
+
+  const expected = "0F01000000000005";
+  const actual = generateCommand(command);
+
+  expect(actual).toEqual(expected);
+});
+
+test("Restart generation", function restart() {
+  const command: IRawCommand = {
+    id: 1,
+    type: "RESTART",
+    params: {},
+  };
+
+  const expected = "0E01000000000004";
+  const actual = generateCommand(command);
+
+  expect(actual).toEqual(expected);
+});
+
+test("Save generation", function save() {
+  const command: IRawCommand = {
+    id: 1,
+    type: "SAVE",
+    params: {},
+  };
+
+  const expected = "AA01000000000005";
+  const actual = generateCommand(command);
+
+  expect(actual).toEqual(expected);
+});
+
+test("Stop generation", function stop() {
+  const command: IRawCommand = {
+    id: 1,
+    type: "STOP",
+    params: {},
+  };
+
+  const expected = "BB01000000000007";
+  const actual = generateCommand(command);
+
+  expect(actual).toEqual(expected);
+});


### PR DESCRIPTION
Closes #25 

**Változás a specifikációhoz képest:** 
Mivel a specifikáció idején még Deno-n futott a projekt `Uint8Array`-ok felhasználásával terveztem a megvalósítást; de mivel időközben áttértünk NodeJS-re, ezért a Buffer API lett használva. 